### PR TITLE
Features/witi 211 vbase fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.2.0] - 2022-09-21
+
 ## [2.1.0] - 2022-09-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.1.0] - 2022-09-21
+
 ### Added
 
 - Allow users to set auto approval for new organization with a new setting fields

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "b2b-organizations-graphql",
   "vendor": "syatt",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "title": "B2B Organizations",
   "description": "App to create and manage B2B Organizations and Cost Centers",
   "mustUpdateAt": "2022-08-28",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "b2b-organizations-graphql",
   "vendor": "vtex",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "title": "B2B Organizations",
   "description": "App to create and manage B2B Organizations and Cost Centers",
   "mustUpdateAt": "2022-08-28",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "b2b-organizations-graphql",
-  "vendor": "vtex",
+  "vendor": "syatt",
   "version": "2.1.0",
   "title": "B2B Organizations",
   "description": "App to create and manage B2B Organizations and Cost Centers",

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -39,14 +39,6 @@ export const COST_CENTER_FIELDS = [
 ]
 export const COST_CENTER_SCHEMA_VERSION = 'v0.0.7'
 
-export const B2B_SETTINGS_DATA_ENTITY = 'b2b_settings'
-export const B2B_SETTINGS_FIELDS = [
-  'autoApprove',
-  'defaultPaymentTerms',
-  'defaultPriceTables',
-]
-export const B2B_SETTINGS_SCHEMA_VERSION = 'v0.0.8'
-
 export const schemas = [
   {
     name: ORGANIZATION_REQUEST_DATA_ENTITY,
@@ -178,28 +170,6 @@ export const schemas = [
         },
       },
       'v-indexed': ['name', 'organization', 'businessDocument'],
-      'v-immediate-indexing': true,
-      'v-cache': false,
-    },
-  },
-  {
-    name: B2B_SETTINGS_DATA_ENTITY,
-    version: B2B_SETTINGS_SCHEMA_VERSION,
-    body: {
-      properties: {
-        autoApprove: {
-          type: 'boolean',
-          title: 'Auto Approve',
-        },
-        defaultPaymentTerms: {
-          type: 'array',
-          title: 'Default Payment Terms',
-        },
-        defaultPriceTables: {
-          type: 'array',
-          title: 'Default Price Tables',
-        },
-      },
       'v-immediate-indexing': true,
       'v-cache': false,
     },

--- a/node/resolvers/Mutations/Settings.ts
+++ b/node/resolvers/Mutations/Settings.ts
@@ -31,13 +31,25 @@ const B2BSettings = {
 
     const B2B_SETTINGS_DATA_ENTITY = 'b2b_settings'
 
+    // Get current settings to save them depending on where the saveB2BSettings is coming from. Custom fields come without autoApprove settings and vice versa.
+    const currentB2BSettings: B2BSettingsInput = await vbase.getJSON(
+      B2B_SETTINGS_DATA_ENTITY,
+      'settings'
+    )
+
     try {
       const b2bSettings = {
-        autoApprove,
-        defaultPaymentTerms,
-        defaultPriceTables,
-        organizationCustomFields,
-        costCenterCustomFields,
+        // in case property is not present inside input grab it from  currentB2BSettings
+        autoApprove: autoApprove ?? currentB2BSettings?.autoApprove,
+        defaultPaymentTerms:
+          defaultPaymentTerms ?? currentB2BSettings?.defaultPaymentTerms,
+        defaultPriceTables:
+          defaultPriceTables ?? currentB2BSettings?.defaultPriceTables,
+        organizationCustomFields:
+          organizationCustomFields ??
+          currentB2BSettings?.organizationCustomFields,
+        costCenterCustomFields:
+          costCenterCustomFields ?? currentB2BSettings?.costCenterCustomFields,
       }
 
       await vbase.saveJSON(B2B_SETTINGS_DATA_ENTITY, 'settings', b2bSettings)

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -9,6 +9,7 @@ import UsersMutation from './Mutations/Users'
 import CostCentersQuery from './Queries/CostCenters'
 import OrganizationsQuery from './Queries/Organizations'
 import UsersQuery from './Queries/Users'
+import SettingsQuery from './Queries/Settings'
 import Routes from './Routes'
 
 export const resolvers = {
@@ -32,6 +33,7 @@ export const resolvers = {
     ...CostCentersQuery,
     ...OrganizationsQuery,
     ...UsersQuery,
+    ...SettingsQuery,
   },
   Routes,
 }


### PR DESCRIPTION
#### What problem is this solving?

Saving `customFields` and `autoApprove` was broken as resolvers were refactored. Also fixed saving fields and `autoApprove` settings as they were overriding eath 

#### How to test it?

https://witi211--whitebird.myvtex.com/admin/b2b-organizations/organizations/#/custom-fields

https://witi211--whitebird.myvtex.com/_v/private/syatt.b2b-organizations-graphql@2.2.0/graphiql/v1?operationName=GetB2BSettings&query=query%20GetB2BSettings%20%7B%0A%20%20getB2BSettings%20%40context(provider%3A%20%22syatt.b2b-organizations-graphql%22)%20%7B%0A%20%20%20%20defaultPriceTables%0A%20%20%20%20autoApprove%0A%20%20%20%20defaultPaymentTerms%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20name%0A%20%20%20%20%7D%0A%20%20%20%20organizationCustomFields%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%20%20type%0A%20%20%20%20%7D%0A%20%20%20%20costCenterCustomFields%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%20%20type%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A

