### PR TITLE
hotfix/Ignore 404 on the first call to Vbase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.2.1] - 2022-09-22
+
 ## [2.2.0] - 2022-09-21
 
 ## [2.1.0] - 2022-09-21

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "b2b-organizations-graphql",
   "vendor": "syatt",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "title": "B2B Organizations",
   "description": "App to create and manage B2B Organizations and Cost Centers",
   "mustUpdateAt": "2022-08-28",

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -24,7 +24,7 @@ export const ORGANIZATION_FIELDS = [
   'created',
   'customFields',
 ]
-export const ORGANIZATION_SCHEMA_VERSION = 'v0.0.7'
+export const ORGANIZATION_SCHEMA_VERSION = 'v0.0.8'
 
 export const COST_CENTER_DATA_ENTITY = 'cost_centers'
 export const COST_CENTER_FIELDS = [
@@ -126,7 +126,7 @@ export const schemas = [
           format: 'date-time',
         },
         customFields: {
-          type: ['array', 'null'],
+          type: 'array',
           title: 'Custom Fields',
         },
       },

--- a/node/resolvers/Queries/Settings.ts
+++ b/node/resolvers/Queries/Settings.ts
@@ -20,6 +20,12 @@ const B2BSettings = {
         'settings',
         true
       )
+
+      settings = {
+        ...settings,
+        // if organizationCustomFields is null, set it to an empty array
+        organizationCustomFields: settings?.organizationCustomFields ?? [],
+      }
     } catch (e) {
       if (e.message) {
         throw new GraphQLError(e.message)

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -100,6 +100,7 @@ interface Organization {
   paymentTerms: PaymentTerm[]
   status: string
   created: string
+  customFields?: CustomField[]
 }
 
 interface CostCenter {


### PR DESCRIPTION
#### What problem is this solving?

Fixed the issue where first call to save `customFields` would come back as 404 - because Vbase table doesn't exist yet
Fixed an issue where GraphQL would complain about expecting array, while `customField` were set to `null`

#### How to test it?

https://renwilltestsep22--renwil.myvtex.com/_v/auth-server/v1/login?ReturnUrl=%2F_v%2Fprivate%2Fsyatt.b2b-organizations-graphql%402.2.1%2Fgraphiql%2Fv1

https://renwilltestsep22--renwil.myvtex.com/_v/private/syatt.b2b-organizations-graphql@2.2.1/graphiql/v1?operationName=GetOrganization&query=query%20GetOrganization(%24id%3A%20ID%20%3D%20%229849e4a1-35cc-11ed-83ab-0e5a03d033a9%22)%20%7B%0A%20%20getOrganizationById(id%3A%20%24id)%0A%20%20%20%20%40context(provider%3A%20%22syatt.b2b-organizations-graphql%22)%20%7B%0A%20%20%20%20id%0A%20%20%20%20name%0A%20%20%20%20tradeName%0A%20%20%20%20status%0A%20%20%20%20created%0A%20%20%20%20collections%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20name%0A%20%20%20%20%7D%0A%20%20%20%20paymentTerms%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20name%0A%20%20%20%20%7D%0A%20%20%20%20priceTables%0A%20%20%20%20costCenters%0A%20%20%20%20customFields%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%20%20value%0A%20%20%20%20%20%20type%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A%20

