### PR TITLE
WITI-319-Adding dropdown fields logic

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -370,6 +370,7 @@ input OrganizationInput {
   tradeName: String
   b2bCustomerAdmin: B2BUserInput
   defaultCostCenter: DefaultCostCenterInput
+  customFields: [CustomFieldInput]
 }
 
 input B2BUserInput {
@@ -429,23 +430,30 @@ input SalesChannelsInput {
 
 enum CustomFieldType {
   text
+  dropdown
 }
 
 type CustomField {
   name: String
   type: CustomFieldType
   value: String
+  dropdownValues: [DropdownValue]
+  useOnRegistration: Boolean
 }
 
 type SettingsCustomField {
   name: String
   type: CustomFieldType
+  dropdownValues: [DropdownValue]
+  useOnRegistration: Boolean
 }
 
 input CustomFieldInput {
   name: String!
   type: CustomFieldType!
   value: String
+  dropdownValues: [DropdownValueInput]
+  useOnRegistration: Boolean
 }
 
 type B2BSettings {
@@ -462,4 +470,14 @@ input B2BSettingsInput {
   defaultPriceTables: [String]
   organizationCustomFields: [CustomFieldInput]
   costCenterCustomFields: [CustomFieldInput]
+}
+
+type DropdownValue {
+  value: String
+  label: String
+}
+
+input DropdownValueInput {
+  value: String
+  label: String
 }

--- a/node/resolvers/Mutations/Organizations.ts
+++ b/node/resolvers/Mutations/Organizations.ts
@@ -22,7 +22,7 @@ const Organizations = {
   createOrganization: async (
     _: void,
     {
-      input: { name, tradeName, defaultCostCenter },
+      input: { name, tradeName, defaultCostCenter, customFields },
     }: { input: OrganizationInput },
     ctx: Context
   ) => {
@@ -46,7 +46,7 @@ const Organizations = {
         created: now,
         paymentTerms: [],
         priceTables: [],
-        customFields: [],
+        customFields: customFields ?? [],
         status: ORGANIZATION_STATUSES.ACTIVE,
       }
 
@@ -99,7 +99,13 @@ const Organizations = {
   createOrganizationRequest: async (
     _: void,
     {
-      input: { name, tradeName, b2bCustomerAdmin, defaultCostCenter },
+      input: {
+        name,
+        tradeName,
+        b2bCustomerAdmin,
+        defaultCostCenter,
+        customFields,
+      },
     }: { input: OrganizationInput },
     ctx: Context
   ) => {
@@ -151,6 +157,7 @@ const Organizations = {
       status,
       notes: '',
       defaultCostCenter,
+      customFields,
       created: now,
     }
 
@@ -177,7 +184,7 @@ const Organizations = {
           logger,
           (settings?.defaultPaymentTerms as unknown) as PaymentTerm[],
           (settings?.defaultPriceTables as unknown) as Price[],
-          (settings?.organizationCustomFields as unknown) as CustomField[],
+          customFields,
           Organizations,
           ctx
         )

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -43,6 +43,7 @@ interface OrganizationInput {
   tradeName?: string
   b2bCustomerAdmin: B2BCustomerInput
   defaultCostCenter: DefaultCostCenterInput
+  customFields?: CustomFields
 }
 
 interface B2BCustomerInput {
@@ -164,13 +165,15 @@ interface Price {
 
 interface CustomField {
   name: string
-  type: 'text'
+  type: 'text' | 'dropdown'
   value: string
+  dropdownValues?: Array<{ label: string; value: string }> | null
+  useOnRegistration?: boolean
 }
 
 interface CustomFieldSetting {
   name: string
-  type: 'text'
+  type: 'text' | 'dropdown'
 }
 
 interface B2BSettingsInput {


### PR DESCRIPTION
#### What problem is this solving?

Adding a dropdown builder and useOnRegistration boolean for Custom fields in order to have them appear on organization registration page

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

Custom fields builder:
https://witi319--whitebird.myvtex.com/admin/b2b-organizations/organizations/#/custom-fields

Custom fields saved after registration: 
https://witi319--whitebird.myvtex.com/admin/b2b-organizations/organizations/f68bac65-5c68-11ed-83ab-0a1be9fca741/#/default

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/44775362/200048467-bb0613f5-abe3-42f5-be9d-149651da5853.png)

![Screen Shot 2022-11-04 at 14 24 13](https://user-images.githubusercontent.com/44775362/200048717-5ddf3dca-37b9-4122-b685-a565fd984682.png)

![Screen Shot 2022-11-04 at 14 24 25](https://user-images.githubusercontent.com/44775362/200048708-4071d1ef-549f-4e5b-a7df-6930d24e6a26.png)

#### Describe alternatives you've considered, if any.



Considered hard-coding the dropdown, but that would 

not work as the app is used both for renwil and whitebird.

#### Related to / Depends on

https://github.com/syatt-io/b2b-organizations/pull/13
